### PR TITLE
Jelly Bean Rename III: The Great Re-rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository is a collection of reconstructed manifests for pre-release build
 | [`zombiebread`]                          | Android 2.3      |          
 | [`froyocomb`]                            | Android 3.0-3.2  |            
 | [`i-scream-sandwich`]                    | Android 4.0      |       
-| [`jelly-flavored-beans`]                 | Android 4.1-4.3  |          
+| [`jolly-bean-jolly-bean`]                | Android 4.1-4.3  |          
 | [`have-a-key-lime-pie`]                  | Android 4.4      |  
 | [`thou-shalt-take-the-L`]                | Android 5.0      |           
 | [`nothing-rhymes-with-nougat`]           | Android 7.0-7.1  |          
@@ -24,7 +24,7 @@ This repository is a collection of reconstructed manifests for pre-release build
 [`zombiebread`]: https://github.com/froyocomb/android/tree/zombiebread
 [`froyocomb`]:  https://github.com/froyocomb/android/tree/froyocomb
 [`i-scream-sandwich`]: https://github.com/froyocomb/android/tree/i-scream-sandwich
-[`jelly-flavored-beans`]: https://github.com/froyocomb/android/tree/jelly-flavored-beans
+[`jolly-bean-jolly-bean`]: https://github.com/froyocomb/android/tree/jolly-bean-jolly-bean
 [`have-a-key-lime-pie`]:  https://github.com/froyocomb/android/tree/have-a-key-lime-pie
 [`thou-shalt-take-the-L`]: https://github.com/froyocomb/android/tree/thou-shalt-take-the-L
 [`nothing-rhymes-with-nougat`]: https://github.com/froyocomb/android/tree/nothing-rhymes-with-nougat


### PR DESCRIPTION
Jelly Bean repo got renamed.